### PR TITLE
group idを確認できるようにした

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,10 +14,22 @@
   version = "v1.2"
 
 [[projects]]
+  name = "github.com/golang/mock"
+  packages = ["gomock"]
+  revision = "13f360950a79f5864a972c786a10a50e44b69541"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+
+[[projects]]
+  name = "github.com/line/line-bot-sdk-go"
+  packages = ["linebot"]
+  revision = "3a7d66f5efce6ac202f650134609f9d6d163a640"
+  version = "1.0.0"
 
 [[projects]]
   name = "github.com/mattn/go-isatty"
@@ -46,7 +58,7 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["html","html/atom","html/charset"]
+  packages = ["context","context/ctxhttp","html","html/atom","html/charset"]
   revision = "5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec"
 
 [[projects]]
@@ -76,6 +88,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1f1634b1d3aeb7348f015d0b8836c6058ba5c628a832d128a8421973cb20072c"
+  inputs-digest = "1698ee11bbb24a7e8d4f7ca6ed58c740443afdea4d35c9d6cb6d81aaf935f5ef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,3 +28,7 @@
   root-package = "github.com/kutsuzawa/line-reminder"
   go-version = "go1.9.2"
   install = [ "./..." ]
+
+[[constraint]]
+  name = "github.com/line/line-bot-sdk-go"
+  version = "1.0.0"

--- a/main.go
+++ b/main.go
@@ -1,10 +1,10 @@
 package main
 
 import (
+	"github.com/gin-gonic/gin"
+	. "github.com/kutsuzawa/line-reminder/message"
 	"log"
 	"os"
-	. "github.com/kutsuzawa/line-reminder/message"
-	"github.com/gin-gonic/gin"
 )
 
 func SetupRouter() *gin.Engine {
@@ -15,6 +15,7 @@ func SetupRouter() *gin.Engine {
 		v1.POST("reminder", NewMessage(messageType, text).PostReminder)
 		v1.POST("report", NewMessage(messageType, text).PostReport)
 		v1.GET("status/:id", NewMessage(messageType, text).GetStatus)
+		v1.POST("check", NewMessage(messageType, text).Check)
 	}
 	return router
 }

--- a/message/check.go
+++ b/message/check.go
@@ -3,8 +3,8 @@ package message
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/golang/go/src/pkg/net/http"
-	"log"
 	"github.com/line/line-bot-sdk-go/linebot"
+	"log"
 	"os"
 )
 
@@ -18,7 +18,7 @@ func (m *message) Check(c *gin.Context) {
 	}
 
 	for _, event := range received {
-		log.Println(event.Source.GroupID)
+		log.Println("Group ID: " + event.Source.GroupID)
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/message/check.go
+++ b/message/check.go
@@ -1,44 +1,24 @@
 package message
 
 import (
-	"fmt"
 	"github.com/gin-gonic/gin"
-	"log"
-	"os"
-	"github.com/line/line-bot-sdk-go/linebot"
 	"github.com/golang/go/src/pkg/net/http"
+	"log"
+	"github.com/line/line-bot-sdk-go/linebot"
+	"os"
 )
 
 func (m *message) Check(c *gin.Context) {
-	//defer c.Request.Body.Close()
-	//body, err := ioutil.ReadAll(c.Request.Body)
-	//if err != nil {
-	//	fmt.Println("Read ERROR")
-	//}
-	//decoded, err := base64.StdEncoding.DecodeString(c.GetHeader("X-Line-Signature"))
-	//if err != nil {
-	//	fmt.Println("Encode ERROR")
-	//}
-	//hash := hmac.New(sha256.New, []byte(os.Getenv("CHANNELSECRET")))
-	//hash.Write(body)
-	//// Compare decoded signature and `hash.Sum(nil)` by using `hmac.Equal`
-	//fmt.Println("decoded : %s", decoded)
-	//fmt.Println("hash.Sum(nil) : %s", hash.Sum(nil))
-	//if hmac.Equal(decoded, hash.Sum(nil)) {
-	//	log.Println("TEST LOG")
-	//	x, _ := ioutil.ReadAll(c.Request.Body)
-	//	fmt.Printf("%s", string(x))
-	//}
-	//c.JSON(http.StatusOK, c)
-	bot, err := linebot.New(os.Getenv("CHANNEL_SECRET"), os.Getenv("CHANNEL_ACCESS_TOKEN"))
+	//TODO: ACCESS_TOKENを自動で更新できるような仕組みがほしい
+	//有効期限がきれると自分たちで手動で環境変数をセットしなおさなきゃらない。
+	bot, _ := linebot.New(os.Getenv("CHANNEL_SECRET"), os.Getenv("CHANNEL_TOKEN"))
+	received, err := bot.ParseRequest(c.Request)
 	if err != nil {
-		log.Fatal(err)
+		log.Println(err)
 	}
 
-	received, _ := bot.ParseRequest(c.Request)
-
 	for _, event := range received {
-		fmt.Println(event.ReplyToken)
+		log.Println(event.Source.GroupID)
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/message/check.go
+++ b/message/check.go
@@ -1,0 +1,47 @@
+package message
+
+import (
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"log"
+	"os"
+	"github.com/line/line-bot-sdk-go/linebot"
+	"github.com/golang/go/src/pkg/net/http"
+)
+
+func (m *message) Check(c *gin.Context) {
+	//defer c.Request.Body.Close()
+	//body, err := ioutil.ReadAll(c.Request.Body)
+	//if err != nil {
+	//	fmt.Println("Read ERROR")
+	//}
+	//decoded, err := base64.StdEncoding.DecodeString(c.GetHeader("X-Line-Signature"))
+	//if err != nil {
+	//	fmt.Println("Encode ERROR")
+	//}
+	//hash := hmac.New(sha256.New, []byte(os.Getenv("CHANNELSECRET")))
+	//hash.Write(body)
+	//// Compare decoded signature and `hash.Sum(nil)` by using `hmac.Equal`
+	//fmt.Println("decoded : %s", decoded)
+	//fmt.Println("hash.Sum(nil) : %s", hash.Sum(nil))
+	//if hmac.Equal(decoded, hash.Sum(nil)) {
+	//	log.Println("TEST LOG")
+	//	x, _ := ioutil.ReadAll(c.Request.Body)
+	//	fmt.Printf("%s", string(x))
+	//}
+	//c.JSON(http.StatusOK, c)
+	bot, err := linebot.New(os.Getenv("CHANNEL_SECRET"), os.Getenv("CHANNEL_ACCESS_TOKEN"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	received, _ := bot.ParseRequest(c.Request)
+
+	for _, event := range received {
+		fmt.Println(event.ReplyToken)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status": "ok",
+	})
+}

--- a/message/message.go
+++ b/message/message.go
@@ -8,6 +8,7 @@ type Message interface {
 	PostReminder(c *gin.Context)
 	PostReport(c *gin.Context)
 	GetStatus(c *gin.Context)
+	Check(c *gin.Context)
 }
 
 // Reference: https://developers.line.me/ja/docs/messaging-api/reference/#message-objects


### PR DESCRIPTION
## What is this?
* group idをログ出力するようにした。
* CHANEL_TOKENは手動でセットする必要がある。
* 自動でTOKENを発行して、それをセットしたいものだが、頻度は少ないし、実装の優先度は低い

## Test
botを部屋に招待したり、追放したりするとheroku上でgroup idが表示される。

## Review Points
