### PR TITLE
特定のワードのメッセージに反応/status check時のメッセージを変更

### DIFF
--- a/api/check.go
+++ b/api/check.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"encoding/json"
+	"strings"
 )
 
 func Check(c *gin.Context) {
@@ -20,23 +21,21 @@ func Check(c *gin.Context) {
 
 	for _, event := range received {
 		log.Println("groupId: " + event.Source.GroupID)
-		if event.Source.UserID == os.Getenv("TARGET_ID") {
 
-			textMsg := new(TextMessage)
-			byteMsg, _ := event.Message.MarshalJSON()
-			if err := json.Unmarshal(byteMsg, textMsg); err != nil {
-				//画像メッセージの場合もあるからただエラーを出力するだけにする
-				log.Println(err.Error())
-				c.JSON(http.StatusOK, gin.H{
-					"status": "false",
-				})
-			}
+		textMsg := new(TextMessage)
+		byteMsg, _ := event.Message.MarshalJSON()
+		if err := json.Unmarshal(byteMsg, textMsg); err != nil {
+			//画像メッセージの場合もあるからただエラーを出力するだけにする
+			log.Println(err.Error())
+			c.JSON(http.StatusOK, gin.H{
+				"status": "false",
+			})
+		}
 
-			if textMsg.Text == os.Getenv("REPORT_MESSAGE") {
-				err := PostMessage(os.Getenv("REPLY_SUCCESS"))
-				if err != nil {
-					log.Fatal(err.Error())
-				}
+		if strings.Contains(textMsg.Text, os.Getenv("REPORT_MESSAGE")){
+			err := PostMessage(os.Getenv("REPLY_SUCCESS"))
+			if err != nil {
+				log.Fatal(err.Error())
 			}
 		}
 	}

--- a/api/check.go
+++ b/api/check.go
@@ -18,6 +18,7 @@ func Check(c *gin.Context) {
 
 	for _, event := range received {
 		log.Println("groupId: " + event.Source.GroupID)
+		log.Println("satuka: " + event.Source.UserID)
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/api/check.go
+++ b/api/check.go
@@ -3,9 +3,11 @@ package api
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/line/line-bot-sdk-go/linebot"
-	"os"
 	"log"
 	"net/http"
+	"os"
+
+	"encoding/json"
 )
 
 func Check(c *gin.Context) {
@@ -18,7 +20,25 @@ func Check(c *gin.Context) {
 
 	for _, event := range received {
 		log.Println("groupId: " + event.Source.GroupID)
-		log.Println("satuka: " + event.Source.UserID)
+		if event.Source.UserID == os.Getenv("TARGET_ID") {
+
+			textMsg := new(TextMessage)
+			byteMsg, _ := event.Message.MarshalJSON()
+			if err := json.Unmarshal(byteMsg, textMsg); err != nil {
+				//画像メッセージの場合もあるからただエラーを出力するだけにする
+				log.Println(err.Error())
+				c.JSON(http.StatusOK, gin.H{
+					"status": "false",
+				})
+			}
+
+			if textMsg.Text == os.Getenv("REPORT_MESSAGE") {
+				err := PostMessage(os.Getenv("REPLY_SUCCESS"))
+				if err != nil {
+					log.Fatal(err.Error())
+				}
+			}
+		}
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/api/line.go
+++ b/api/line.go
@@ -5,6 +5,11 @@ import (
 	"os"
 )
 
+type TextMessage struct {
+	Type	string 	`json: type`
+	Text	string  `json: text`
+}
+
 func PostMessage(message string) error{
 	config := NewLineConfig()
 	bot, err := linebot.New(os.Getenv("CHANNEL_SECRET"), config.AccessToken)

--- a/api/status.go
+++ b/api/status.go
@@ -2,11 +2,11 @@ package api
 
 import (
 	"github.com/gin-gonic/gin"
+	"log"
 	"net/http"
 	"os"
 	"strconv"
 	"strings"
-	"log"
 )
 
 func GetStatus(c *gin.Context) {
@@ -15,7 +15,7 @@ func GetStatus(c *gin.Context) {
 	status := os.Getenv(statusKey)
 	statusFlag, _ := strconv.ParseBool(status)
 
-	if ! statusFlag {
+	if !statusFlag {
 		err := PostMessage(os.Getenv("STATUS_MESSAGE"))
 		if err != nil {
 			log.Println(err.Error())

--- a/api/status.go
+++ b/api/status.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"log"
 )
 
 func GetStatus(c *gin.Context) {
@@ -14,11 +15,14 @@ func GetStatus(c *gin.Context) {
 	status := os.Getenv(statusKey)
 	statusFlag, _ := strconv.ParseBool(status)
 
-	if statusFlag {
-		c.JSON(http.StatusOK, gin.H{
-			"status": status,
-		})
-	} else {
-		PostReminder(c)
+	if ! statusFlag {
+		err := PostMessage(os.Getenv("STATUS_MESSAGE"))
+		if err != nil {
+			log.Println(err.Error())
+		}
 	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status": status,
+	})
 }


### PR DESCRIPTION
## What is this?
* 特定のワード`$REPORT_MESSAGE`を含む投稿を検知すると`$REPLY_SUCCESS`を投稿する
* botからのメッセージはwebhookが反応したいみたいでやりたいことはできなかった。
* statusチェックの際にreminderを起動することはやめて、独自のメッセージ`STATUS_MESSAGE`を投稿するようにした
## Test

## Review Points
