### PR TITLE
リプライのメソッド変更/goのversion up(heroku)

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -26,7 +26,7 @@
 
 [metadata.heroku]
   root-package = "github.com/kutsuzawa/line-reminder"
-  go-version = "go1.9.2"
+  go-version = "go1.9.3"
   install = [ "./..." ]
 
 [[constraint]]

--- a/api/check.go
+++ b/api/check.go
@@ -32,8 +32,8 @@ func Check(c *gin.Context) {
 			})
 		}
 
-		if strings.Contains(textMsg.Text, os.Getenv("REPORT_MESSAGE")){
-			err := PostMessage(os.Getenv("REPLY_SUCCESS"))
+		if textMsg.Text == os.Getenv("REPORT_MESSAGE") {
+			err := ReplyMessage(event.ReplyToken, os.Getenv("REPLY_SUCCESS"))
 			if err != nil {
 				log.Fatal(err.Error())
 			}

--- a/api/check.go
+++ b/api/check.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"encoding/json"
-	"strings"
 )
 
 func Check(c *gin.Context) {

--- a/api/line.go
+++ b/api/line.go
@@ -22,3 +22,16 @@ func PostMessage(message string) error{
 	}
 	return nil
 }
+
+func ReplyMessage(token string, messsage string) error {
+	config := NewLineConfig()
+	bot, err := linebot.New(os.Getenv("CHANNEL_SECRET"), config.AccessToken)
+	if err != nil {
+		return err
+	}
+
+	if _, err := bot.ReplyMessage(token, linebot.NewTextMessage(messsage)).Do(); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## What is this?
* 以前まではpostmessageをreplyのようにしていたが、replymessageを使うようにした。
* webhookをつかってやっていたから全然恩恵がない

* go1.9.2はherokuにdeprecatedと怒られたため、1.9.3にあげた

## Test

## Review Points
