### PR TITLE
status更新のタイミングを変更

### DIFF
--- a/reminder/controller.go
+++ b/reminder/controller.go
@@ -53,11 +53,11 @@ func (lc *lineController) Remind(id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	status := SetStatus(id, "false")
 	message := "To " + target + "\n" + os.Getenv("REMINDER_MESSAGE")
 	if err := lc.service.Send(message); err != nil {
 		return "", err
 	}
-	status := SetStatus(id, "false")
 	return status, nil
 }
 


### PR DESCRIPTION
## What is this?
* remind messageを送信してからstatusをfalseにしていたのだが、あまりに早く返信されるとstatusがバグってしまう問題が発生した(返信され、trueになったあと、falseに戻してしまう)

## Test
単体テストを実施
```
$ ginkgo -r -v
```

## Review Points
